### PR TITLE
ERC-7617/7618: Update status. Fix a link to a w3link example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ web3://0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/balanceOf/nemorino.eth?returns
 
 This URL will fetch the balance of USDC of the account ``nemorino.eth``.
 
-> ⏩ Try now with a [web3:// gateway](https://usdc.w3eth.io/balanceOf/nemorino.eth?returns=(uint256)), or with the others ``web3://`` clients
+> ⏩ Try now with a [web3:// gateway](https://0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48.w3eth.io/balanceOf/nemorino.eth?returns=(uint256)), or with the others ``web3://`` clients
 
 
 

--- a/structure/base.md
+++ b/structure/base.md
@@ -24,5 +24,5 @@ Here is the list of ERCs :
 - [ERC-6821](https://eips.ethereum.org/EIPS/eip-6821): (Draft) ENS resolution : support for the ``contentcontract`` TXT field to point to a contract in another chain. Still in draft status.
 - [ERC-6944](https://eips.ethereum.org/EIPS/eip-6944): (Draft) New resolve mode offloading some parsing processing on the browser side, based on [ERC-5219](https://eips.ethereum.org/EIPS/eip-5219). Still in draft status.
 - [ERC-7087](https://eips.ethereum.org/EIPS/eip-7087) : (Draft) Auto mode : Add MIME type support. Still in draft status.
-- [ERC-7617](https://github.com/ethereum/ERCs/pull/245) : (Pending) Add chunk support in ERC-6944 resource request mode. Still in pending merge status.
-- [ERC-7618](https://github.com/ethereum/ERCs/pull/246) : (Pending) Add Content-encoding handling in ERC-6944 resource request mode. Still in pending merge status.
+- [ERC-7617](https://eips.ethereum.org/EIPS/eip-7617) : (Draft) Add chunk support in ERC-6944 resource request mode. Still in pending merge status.
+- [ERC-7618](https://eips.ethereum.org/EIPS/eip-7618) : (Draft) Add Content-encoding handling in ERC-6944 resource request mode. Still in pending merge status.

--- a/structure/mode-resource-request.md
+++ b/structure/mode-resource-request.md
@@ -91,7 +91,7 @@ contract TerraformNavigator is IDecentralizedApp {
 
 ## Chunk support
 
-🟠 This feature is in PR pending status ([ERC-7617](https://github.com/ethereum/ERCs/pull/245/files)) and could be modified.
+🟠 This feature is in draft status ([ERC-7617](https://eips.ethereum.org/EIPS/eip-7617)) and could be modified.
 
 The resource you want to return may be so large you will run into the max gas limitation of the RPC provider used. To handle this problem, you can use the `chunking` feature: in your `request()` return, return a `web3-next-chunk` HTTP header with a `web3://` URL pointing to the next chunk of data. It will then loop until there is no more `web3-next-chunk` HTTP header returned. Please note that : 
 
@@ -118,7 +118,7 @@ web3://0x8e990356262a2f8164981298e167c3ad2409faa1:11155111/getFile/abcd
 
 ## Compression / Content-encoding support
 
-🟠 This feature is in PR pending status ([ERC-7618](https://github.com/ethereum/ERCs/pull/246/files)) and could be modified.
+🟠 This feature is in draft status ([ERC-7618](https://eips.ethereum.org/EIPS/eip-7618)) and could be modified.
 
 To optimize blockchain storage cost, you may want to store compressed assets, and return a `Content-encoding` HTTP header of value `gzip` or `br` (brotli). In this case, the protocol will decompress the data, and return it to the client, and the `Content-encoding` HTTP header won't be returned to the client.
 


### PR DESCRIPTION
ERC-7617/7618 are now been merged : update their links!

Also, a web3:// URL example was edited, but not his w3link.io URL: Fixed.

Thanks!